### PR TITLE
Fix filter default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.0
+   1.17.1

--- a/lib/ical_filter_proxy.rb
+++ b/lib/ical_filter_proxy.rb
@@ -13,10 +13,7 @@ require_relative 'ical_filter_proxy/web_app'
 
 module IcalFilterProxy
   def self.start
-    config_file_path = File.expand_path('../../config.yml', __FILE__)
-    config = YAML.load(open(config_file_path))
-
-    filters = Hash.new({})
+    filters = Hash.new { |hash, key| hash[key] = {} }
     config.each do |filter_name, filter_config|
       calendar = Calendar.new(filter_config["ical_url"], filter_config["timezone"])
       filter_config["rules"].each do |rule|
@@ -28,5 +25,10 @@ module IcalFilterProxy
     end
 
     WebApp.new(filters)
+  end
+
+  def self.config
+    config_file_path = File.expand_path('../../config.yml', __FILE__)
+    config = YAML.load(open(config_file_path))
   end
 end

--- a/lib/ical_filter_proxy.rb
+++ b/lib/ical_filter_proxy.rb
@@ -13,15 +13,17 @@ require_relative 'ical_filter_proxy/web_app'
 
 module IcalFilterProxy
   def self.start
-    filters = Hash.new { |hash, key| hash[key] = {} }
+    filters = {}
     config.each do |filter_name, filter_config|
       calendar = Calendar.new(filter_config["ical_url"], filter_config["timezone"])
       filter_config["rules"].each do |rule|
         calendar.add_rule(rule["field"], rule["operator"], rule["val"])
       end
 
-      filters[filter_name][:calendar] = calendar
-      filters[filter_name][:api_key] = filter_config["api_key"]
+      filters[filter_name] = {
+        calendar: calendar,
+        api_key: filter_config["api_key"]
+      }
     end
 
     WebApp.new(filters)

--- a/spec/ical_filter_proxy_spec.rb
+++ b/spec/ical_filter_proxy_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe IcalFilterProxy do
+  describe '.start' do
+    let(:web_app) { IcalFilterProxy.start }
+
+    before do
+      example_config_file_path = File.expand_path('../../config.yml.example', __FILE__)
+      example_config = YAML.load(open(example_config_file_path))
+      expect(IcalFilterProxy).to receive(:config).and_return(example_config)
+    end
+
+    it "initializes a WebApp with filters from config" do
+      expect(web_app.filters['rota']).to have_key(:calendar)
+    end
+
+    it "sets up a filters hash that defaults to empty hash" do
+      expect(web_app.filters['foo']).to eq({})
+    end
+  end
+end

--- a/spec/ical_filter_proxy_spec.rb
+++ b/spec/ical_filter_proxy_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe IcalFilterProxy do
       expect(web_app.filters['rota']).to have_key(:calendar)
     end
 
-    it "sets up a filters hash that defaults to empty hash" do
-      expect(web_app.filters['foo']).to eq({})
+    it "sets up a filters hash that defaults to nil" do
+      expect(web_app.filters['foo']).to be_nil
     end
   end
 end


### PR DESCRIPTION
This fixes an issue where any bogus url request would return the last calendar filter defined in `config.yml`.