### PR TITLE
Array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ my_calendar_name:
       - field: start_time # start_time and end_time supported
         operator: not-equals # equals and not-equals supported
         val: "09:00" # A time in 24hour format, zero-padded
+      - field: summary # summary and description supported
+        operator: startswith # startswith and not-startswith supported
+        val: # array of values also supported
+          - Planning
+          - Daily Standup
 ```
 
 ## Additional Rules

--- a/lib/ical_filter_proxy/filter_rule.rb
+++ b/lib/ical_filter_proxy/filter_rule.rb
@@ -1,26 +1,29 @@
 module IcalFilterProxy
   class FilterRule
 
-    attr_accessor :field, :operator, :value
+    attr_accessor :field, :operator, :value, :negation
 
     def initialize(field, operator, value)
       self.field = field
-      self.operator = operator
+      operator =~ /^(not-)?(\w+)/
+      self.negation = !$1.nil?
+      self.operator = $2
       self.value = value
     end
 
     def match_event?(filterable_event)
       event_data = filterable_event.send(field.to_sym)
+      negation ^ evaluate(event_data)
+    end
 
+    private
+
+    def evaluate(event_data)
       case operator
       when 'equals'
         event_data == value
-      when 'not-equals'
-        event_data != value
       when 'startswith'
         event_data.start_with?(value)
-      when 'not-startswith'
-        !event_data.start_with?(value)
       else
         false
       end

--- a/lib/ical_filter_proxy/filter_rule.rb
+++ b/lib/ical_filter_proxy/filter_rule.rb
@@ -1,31 +1,35 @@
 module IcalFilterProxy
   class FilterRule
 
-    attr_accessor :field, :operator, :value, :negation
+    attr_accessor :field, :operator, :values, :negation
 
-    def initialize(field, operator, value)
+    def initialize(field, operator, values)
       self.field = field
       operator =~ /^(not-)?(\w+)/
       self.negation = !$1.nil?
       self.operator = $2
-      self.value = value
+      self.values = values
     end
 
     def match_event?(filterable_event)
       event_data = filterable_event.send(field.to_sym)
-      negation ^ evaluate(event_data)
+      negation ^ evaluate(event_data, values)
     end
 
     private
 
-    def evaluate(event_data)
-      case operator
-      when 'equals'
-        event_data == value
-      when 'startswith'
-        event_data.start_with?(value)
+    def evaluate(event_data, value)
+      if value.is_a? Array
+        value.reduce(false) { |r, v| r |= evaluate(event_data, v) }
       else
-        false
+        case operator
+        when 'equals'
+          event_data == value
+        when 'startswith'
+          event_data.start_with?(value)
+        else
+          false
+        end
       end
     end
   end

--- a/spec/filter_rule_spec.rb
+++ b/spec/filter_rule_spec.rb
@@ -2,11 +2,22 @@ require 'spec_helper'
 
 RSpec.describe IcalFilterProxy::FilterRule do
   describe '.new' do
-    it 'accepts field, operatior and value' do
+    it 'accepts field, operator and value' do
       filter_rule = described_class.new('start_time', 'equals', '09:00')
 
       expect(filter_rule).to be_a(described_class)
       expect(filter_rule.field).to eq('start_time')
+      expect(filter_rule.negation).to eq(false)
+      expect(filter_rule.operator).to eq('equals')
+      expect(filter_rule.value).to eq('09:00')
+    end
+
+    it 'accepts field, negative operator and value' do
+      filter_rule = described_class.new('start_time', 'not-equals', '09:00')
+
+      expect(filter_rule).to be_a(described_class)
+      expect(filter_rule.field).to eq('start_time')
+      expect(filter_rule.negation).to eq(true)
       expect(filter_rule.operator).to eq('equals')
       expect(filter_rule.value).to eq('09:00')
     end

--- a/spec/filter_rule_spec.rb
+++ b/spec/filter_rule_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IcalFilterProxy::FilterRule do
       expect(filter_rule.field).to eq('start_time')
       expect(filter_rule.negation).to eq(false)
       expect(filter_rule.operator).to eq('equals')
-      expect(filter_rule.value).to eq('09:00')
+      expect(filter_rule.values).to eq('09:00')
     end
 
     it 'accepts field, negative operator and value' do
@@ -19,12 +19,22 @@ RSpec.describe IcalFilterProxy::FilterRule do
       expect(filter_rule.field).to eq('start_time')
       expect(filter_rule.negation).to eq(true)
       expect(filter_rule.operator).to eq('equals')
-      expect(filter_rule.value).to eq('09:00')
+      expect(filter_rule.values).to eq('09:00')
+    end
+
+    it 'accepts field, operator and value array' do
+      filter_rule = described_class.new('start_time', 'equals', ['09:00', '10:00'])
+
+      expect(filter_rule).to be_a(described_class)
+      expect(filter_rule.field).to eq('start_time')
+      expect(filter_rule.negation).to eq(false)
+      expect(filter_rule.operator).to eq('equals')
+      expect(filter_rule.values).to eq(['09:00', '10:00'])
     end
   end
 
   describe '#match_event?' do
-    let(:dummy_event) { instance_double("FilterableEventAdapter", :event, start_time: '09:00') }
+    let(:dummy_event) { instance_double("FilterableEventAdapter", :event, start_time: '09:00', summary: 'Foobar') }
 
     context 'when operator is equals' do
       it 'matches events where the value is the same as the filter value' do
@@ -70,6 +80,30 @@ RSpec.describe IcalFilterProxy::FilterRule do
 
       it 'rejects events where the value starts with the filter value' do
         non_matching_filter_rule = described_class.new('start_time', 'not-startswith', '09')
+        expect(non_matching_filter_rule.match_event?(dummy_event)).to be false
+      end
+    end
+
+    context 'when operator is startswith and value an array' do
+      it 'matches events where the value is the same as the filter value' do
+        matching_filter_rule = described_class.new('summary', 'startswith', ['Foo', 'Nothing'])
+        expect(matching_filter_rule.match_event?(dummy_event)).to be true
+      end
+
+      it 'rejects events where the value is different to the filter value' do
+        non_matching_filter_rule = described_class.new('summary', 'startswith', ['Bar', 'Nothing'])
+        expect(non_matching_filter_rule.match_event?(dummy_event)).to be false
+      end
+    end
+
+    context 'when operator is not-startswith and value an array' do
+      it 'matches events where the value does not start with the filter value' do
+        matching_filter_rule = described_class.new('summary', 'not-startswith', ['Bar', 'Nothing'])
+        expect(matching_filter_rule.match_event?(dummy_event)).to be true
+      end
+
+      it 'rejects events where the value starts with the filter value' do
+        non_matching_filter_rule = described_class.new('summary', 'not-startswith', ['Foo', 'Nothing'])
         expect(non_matching_filter_rule.match_event?(dummy_event)).to be false
       end
     end


### PR DESCRIPTION
The configured filter rule values can now be arrays, with the semantic of "match-one-of" for positive and "match-none-of" for negated operators.

I also generalized the match for negated operators.