### PR TITLE
Add support for mapping event values based on filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ my_calendar_name:
         val: # array of values also supported
           - Planning
           - Daily Standup
+   map:
+      - field: summary
+        rules:
+          - field: summary
+            operator: equals
+            val: Busy
+        val: A Meeting
+      - field: summary
+        rules:
+          - field: summary
+            operator: equals
+            val: Tentative
+        val: A Tentative Meeting
 ```
 
 ## Additional Rules
@@ -31,6 +44,10 @@ my_calendar_name:
 At the moment rules are pretty simple, supporting only start times, end times, equals and
 not-equals as that satisfies my use case. To add support for additional rules please extend
 `lib/ical_filter_proxy/filter_rule.rb`. Pull requests welcome.
+
+## Mappings
+
+Fields can be remapped by supplying a set of rules, the field to remap, and the new value.
 
 ## Installing/Running
 

--- a/lib/ical_filter_proxy.rb
+++ b/lib/ical_filter_proxy.rb
@@ -19,7 +19,7 @@ module IcalFilterProxy
 
       filter_config["rules"].each do |rule|
         calendar.add_rule(rule["field"], rule["operator"], rule["val"])
-      end
+      end unless filter_config["rules"].nil?
 
       filter_config["map"].each do |mapping|
         rules = []
@@ -29,7 +29,7 @@ module IcalFilterProxy
         end
 
         calendar.add_mapping(mapping["field"], rules, mapping["val"])
-      end
+      end unless filter_config["map"].nil?
 
       filters[filter_name] = calendar
     end

--- a/lib/ical_filter_proxy.rb
+++ b/lib/ical_filter_proxy.rb
@@ -9,6 +9,7 @@ require 'forwardable'
 
 require_relative 'ical_filter_proxy/calendar'
 require_relative 'ical_filter_proxy/filter_rule'
+require_relative 'ical_filter_proxy/mapping'
 require_relative 'ical_filter_proxy/filterable_event_adapter'
 
 module IcalFilterProxy
@@ -18,6 +19,16 @@ module IcalFilterProxy
 
       filter_config["rules"].each do |rule|
         calendar.add_rule(rule["field"], rule["operator"], rule["val"])
+      end
+
+      filter_config["map"].each do |mapping|
+        rules = []
+
+        mapping["rules"].each do |rule|
+          rules << FilterRule.new(rule["field"], rule["operator"], rule["val"])
+        end
+
+        calendar.add_mapping(mapping["field"], rules, mapping["val"])
       end
 
       filters[filter_name] = calendar

--- a/lib/ical_filter_proxy/calendar.rb
+++ b/lib/ical_filter_proxy/calendar.rb
@@ -1,6 +1,6 @@
 module IcalFilterProxy
   class Calendar
-    attr_accessor :ical_url, :api_key, :timezone, :filter_rules
+    attr_accessor :ical_url, :api_key, :timezone, :filter_rules, :mappings
 
     def initialize(ical_url, api_key, timezone = 'UTC')
       self.ical_url = ical_url
@@ -8,16 +8,25 @@ module IcalFilterProxy
       self.timezone = timezone
 
       self.filter_rules = []
+      self.mappings = []
     end
 
     def add_rule(field, operator, value)
       self.filter_rules << FilterRule.new(field, operator, value)
     end
 
+    def add_mapping(field, rules, value)
+      self.mappings << Mapping.new(field, rules, value)
+    end
+
     def filtered_calendar
       filtered_calendar = Icalendar::Calendar.new
       filtered_events.each do |original_event|
-        filtered_calendar.add_event(original_event)
+        mapped_event = original_event
+        mappings.each do |mapping|
+          mapped_event.send(mapping.field + "=", mapping.value) if mapping_match?(mapping, FilterableEventAdapter.new(original_event, timezone: timezone))
+        end
+        filtered_calendar.add_event(mapped_event)
       end
       filtered_calendar.to_ical
     end
@@ -34,12 +43,16 @@ module IcalFilterProxy
       filter_rules.empty? || filter_rules.all? { |rule| rule.match_event?(event) }
     end
 
+    def mapping_match?(mapping, event)
+      mapping.rules.empty? || mapping.rules.all? { |rule| rule.match_event?(event) }
+    end
+
     def original_ics
       Icalendar::Calendar.parse(raw_original_ical).first
     end
 
     def raw_original_ical
-      open(ical_url).read
+      URI.open(ical_url).read
     end
   end
 end

--- a/lib/ical_filter_proxy/mapping.rb
+++ b/lib/ical_filter_proxy/mapping.rb
@@ -1,0 +1,16 @@
+module IcalFilterProxy
+  class Mapping
+
+    attr_accessor :field, :rules, :value
+
+    def initialize(field, rules, value)
+      self.field = field
+      self.rules = rules
+      self.value = value
+    end
+
+    def match_event?(filterable_event)
+      rules.match_event?(filterable_event)
+    end
+  end
+end


### PR DESCRIPTION
My default Outlook free/busy sync is annoying to look at.  I'm already filtering out Free and Out-of-Office blocks, but there's no way to change the text on meetings from the "Busy" or "Tentative".  I figured it would be pretty easy to use the existing filter system to add the ability to remap the old text to the new text.  I added part of the YAML I'm using to the README file.

Only potential blockers are that I didn't create a unit test, and that I only have a very basic familiarity with Ruby.  I may not have done things to convention, but I did try to follow any patterns that were in place in the original code.  The missing unit test shouldn't be too big of a deal considering the core logic of `mapping.rb` is delegating to the already-tested-and-unmodified `filter_rule.rb`.

Currently building at `ghcr.io/ndm13/ical-filter-proxy:release`