### PR TITLE
Guard against empty rules set

### DIFF
--- a/lib/ical_filter_proxy.rb
+++ b/lib/ical_filter_proxy.rb
@@ -9,18 +9,13 @@ require 'forwardable'
 
 require_relative 'ical_filter_proxy/calendar'
 require_relative 'ical_filter_proxy/filter_rule'
+require_relative 'ical_filter_proxy/calendar_builder'
 require_relative 'ical_filter_proxy/filterable_event_adapter'
 
 module IcalFilterProxy
   def self.calendars
-    config.each_with_object({}) do |(calendar_name, filter_config), calendars|
-      calendar = Calendar.new(filter_config["ical_url"], filter_config["api_key"], filter_config["timezone"])
-
-      filter_config["rules"].each do |rule|
-        calendar.add_rule(rule["field"], rule["operator"], rule["val"])
-      end
-
-      calendars[calendar_name] = calendar
+    config.transform_values do |calendar_config|
+      CalendarBuilder.new(calendar_config).build
     end
   end
 

--- a/lib/ical_filter_proxy/calendar_builder.rb
+++ b/lib/ical_filter_proxy/calendar_builder.rb
@@ -1,0 +1,36 @@
+module IcalFilterProxy
+  class CalendarBuilder
+
+    attr_reader :calendar_config, :calendar
+
+    def initialize(calendar_config)
+      @calendar_config = calendar_config
+    end
+
+    def build
+      create_calendar
+      add_rules
+
+      calendar
+    end
+
+    private
+
+    def create_calendar
+      @calendar = Calendar.new(calendar_config["ical_url"],
+                               calendar_config["api_key"],
+                               calendar_config["timezone"])
+    end
+
+    def add_rules
+      rules = calendar_config["rules"]
+
+      rules.each do |rule|
+        calendar.add_rule(rule["field"],
+                          rule["operator"],
+                          rule["val"])
+      end
+    end
+
+  end
+end

--- a/lib/ical_filter_proxy/calendar_builder.rb
+++ b/lib/ical_filter_proxy/calendar_builder.rb
@@ -24,6 +24,7 @@ module IcalFilterProxy
 
     def add_rules
       rules = calendar_config["rules"]
+      return unless rules
 
       rules.each do |rule|
         calendar.add_rule(rule["field"],

--- a/spec/calendar_builder_spec.rb
+++ b/spec/calendar_builder_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+require 'spec_helper'
+
+RSpec.describe IcalFilterProxy::CalendarBuilder do
+
+  subject { described_class.new(example_config) }
+
+  describe '#build' do
+    let(:calendar) { subject.build }
+
+    it 'builds a Calendar' do
+      expect(calendar).to be_a(IcalFilterProxy::Calendar)
+    end
+
+    it 'adds ical_url to the Calendar object' do
+      expect(calendar.ical_url).to eq('https://url-to-calendar.ical')
+    end
+
+    it 'adds api_key to the Calenar object' do
+      expect(calendar.api_key).to eq('abc12')
+    end
+
+    it 'adds filters to the Calendar object' do
+      filter_rule = calendar.filter_rules.first
+
+      expect(filter_rule).to be_a(IcalFilterProxy::FilterRule)
+      expect(filter_rule.field).to eq('start_time')
+      expect(filter_rule.operator).to eq('equals')
+      expect(filter_rule.values).to eq('09:00')
+    end
+  end
+
+  def example_config
+    {
+      'ical_url' => 'https://url-to-calendar.ical',
+      'api_key' => 'abc12',
+      'rules' => [
+        { 'field' => 'start_time', 'operator' => 'equals', 'val' => '09:00' }
+      ]
+    }
+  end
+
+end

--- a/spec/calendar_builder_spec.rb
+++ b/spec/calendar_builder_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe IcalFilterProxy::CalendarBuilder do
 
   subject { described_class.new(example_config) }
 
+  let(:example_config) do
+    {
+      'ical_url' => 'https://url-to-calendar.ical',
+      'api_key' => 'abc12',
+      'rules' => [
+        { 'field' => 'start_time', 'operator' => 'equals', 'val' => '09:00' }
+      ]
+    }
+  end
+
   describe '#build' do
     let(:calendar) { subject.build }
 
@@ -21,7 +31,7 @@ RSpec.describe IcalFilterProxy::CalendarBuilder do
       expect(calendar.api_key).to eq('abc12')
     end
 
-    it 'adds filters to the Calendar object' do
+    it 'adds filter rules to the Calendar object' do
       filter_rule = calendar.filter_rules.first
 
       expect(filter_rule).to be_a(IcalFilterProxy::FilterRule)
@@ -29,16 +39,19 @@ RSpec.describe IcalFilterProxy::CalendarBuilder do
       expect(filter_rule.operator).to eq('equals')
       expect(filter_rule.values).to eq('09:00')
     end
-  end
 
-  def example_config
-    {
-      'ical_url' => 'https://url-to-calendar.ical',
-      'api_key' => 'abc12',
-      'rules' => [
-        { 'field' => 'start_time', 'operator' => 'equals', 'val' => '09:00' }
-      ]
-    }
+    context 'when no fitler rules are present' do
+      let(:example_config) do
+        {
+          'ical_url' => 'https://url-to-calendar.ical',
+          'api_key' => 'abc12',
+        }
+      end
+
+      it 'does not attempt to add any rules' do
+        expect(calendar.filter_rules).to be_empty
+      end
+    end
   end
 
 end

--- a/spec/ical_filter_proxy_spec.rb
+++ b/spec/ical_filter_proxy_spec.rb
@@ -22,33 +22,23 @@ RSpec.describe IcalFilterProxy do
 
     let(:calendars) { described_class.calendars }
 
-    it "builds a hash" do
-      expect(calendars).to be_a(Hash)
-    end
-
     it "has an entry for each calendar in the config file" do
       expect(calendars).to have_key('rota')
     end
 
-    it 'creates a Calenar object for each entry' do
-      expect(calendars['rota']).to be_a(IcalFilterProxy::Calendar)
-    end
+    it 'calls CalendarBuilder#build for each entry and stores the return' do
+      calendar_builder = instance_double(IcalFilterProxy::CalendarBuilder)
+      expect(IcalFilterProxy::CalendarBuilder)
+        .to receive(:new)
+        .with(example_config['rota'])
+        .and_return(calendar_builder)
 
-    it 'adds ical_url to the Calendar object' do
-      expect(calendars['rota'].ical_url).to eq('https://url-to-calendar.ical')
-    end
+      calendar = instance_double(IcalFilterProxy::CalendarBuilder)
+      expect(calendar_builder)
+        .to receive(:build)
+        .and_return(calendar)
 
-    it 'adds api_key to the Calenar object' do
-      expect(calendars['rota'].api_key).to eq('abc12')
-    end
-
-    it 'adds filters to the Calendar object' do
-      filter_rule = calendars['rota'].filter_rules.first
-
-      expect(filter_rule).to be_a(IcalFilterProxy::FilterRule)
-      expect(filter_rule.field).to eq('start_time')
-      expect(filter_rule.operator).to eq('equals')
-      expect(filter_rule.values).to eq('09:00')
+      expect(calendars['rota']).to eq(calendar)
     end
   end
 
@@ -63,6 +53,5 @@ RSpec.describe IcalFilterProxy do
       }
     }
   end
-
 
 end


### PR DESCRIPTION
This PR guards against an empty rules set as seen in #16.

To prevent things getting a bit hairy in the `IcalFitlerProxy#calendars` method, I've split that out into it's own builder class. This should also make it easier to add additional pieces of configuration such as required in #18.

Once refactored, it was simply a case of adding a guard clause to `IcalFilterProxy::CalendarBuilder#add_rules` to prevent treating a nil as an array.