### PR TITLE
Fix Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,12 @@ jobs:
       - ruby/rspec-test:
           include: spec/**/*_spec.rb
 
-  build-and-publish:
-    executor: docker/docker
-    steps:
-      - docker/publish:
-          image: darkphnx/ical-filter-proxy
-
-
 workflows:
   test:
     jobs:
       - test
 
-  build-and-publish:
-    # filters:
-    #   branches:
-    #     only: master
-
+  build-and-publish-docker-image:
     jobs:
-      - build-and-publish
+      - docker/publish:
+          image: darkphnx/ical-filter-proxy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,9 @@ jobs:
         include: spec/**/*_spec.rb
 
   build-and-publish:
-    - docker/pubish:
-      image: darkphnx/ical-filter-proxy
+    steps:
+      - docker/pubish:
+        image: darkphnx/ical-filter-proxy
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,6 @@ workflows:
     jobs:
       - docker/publish:
           image: darkphnx/ical-filter-proxy
-    filters:
-      branches:
-        only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-publish:
     executor: docker/docker
     steps:
-      - docker/pubish:
+      - docker/publish:
         image: darkphnx/ical-filter-proxy
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
         include: spec/**/*_spec.rb
 
   build-and-publish:
+    executor: docker/docker
     steps:
       - docker/pubish:
         image: darkphnx/ical-filter-proxy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.0
+  docker: circleci/docker@2.2.0
 
 jobs:
   test:
@@ -13,7 +14,20 @@ jobs:
       - ruby/rspec-test:
         include: spec/**/*_spec.rb
 
+  build-and-publish:
+    - docker/pubish:
+      image: darkphnx/ical-filter-proxy
+
+
 workflows:
-  build:
+  test:
     jobs:
       - test
+
+  build-and-publish:
+    # filters:
+    #   branches:
+    #     only: master
+
+    jobs:
+      - build-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ jobs:
       - checkout
       - ruby/install-deps
       - ruby/rspec-test:
-        include: spec/**/*_spec.rb
+          include: spec/**/*_spec.rb
 
   build-and-publish:
     executor: docker/docker
     steps:
       - docker/publish:
-        image: darkphnx/ical-filter-proxy
+          image: darkphnx/ical-filter-proxy
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,3 +23,6 @@ workflows:
     jobs:
       - docker/publish:
           image: darkphnx/ical-filter-proxy
+    filters:
+      branches:
+        only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-slim
+FROM ruby:2.7-slim
 
 RUN bundle config --global frozen 1
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'activesupport' # Used for it's handy timezone support
 gem 'icalendar'
 gem 'rake'
 gem 'rack', require: false
+gem 'rackup', require: false
 
 gem 'rspec', require: false
 gem 'rspec_junit_formatter', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,9 @@ GEM
     minitest (5.16.3)
     public_suffix (5.0.1)
     rack (3.0.2)
+    rackup (0.2.3)
+      rack (>= 3.0.0.beta1)
+      webrick
     rake (13.0.6)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -44,6 +47,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -52,6 +56,7 @@ DEPENDENCIES
   activesupport
   icalendar
   rack
+  rackup
   rake
   rspec
   rspec_junit_formatter


### PR DESCRIPTION
Fix the docker build broken by the recent upgrade to ruby & gems. 

- Image updated to Ruby 2.7 to be inline with everything else
- Rackup gem added as this was removed in Rack 3

PR also introduces a build and push to dockerhub when new commits are made to master.