### PR TITLE
Build multi-arch docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             docker context create cross-builder
             docker buildx create --name cross-builder cross-builder
-            docker buildx use arm-builder
+            docker buildx use cross-builder
             docker buildx inspect --bootstrap
       - run: 
           name: Cross-Build Image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             docker buildx inspect --bootstrap
       - run:
           name: Login to Dockerhub
-          command: echo "${!DOCKER_PASSWORD}" | docker login -u "${!DOCKER_LOGIN}" --password-stdin
+          command: echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_LOGIN}" --password-stdin
       - run: 
           name: Cross-Build Image
           command: | 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,14 @@ jobs:
       - ruby/rspec-test:
           include: spec/**/*_spec.rb
 
+  cross-build-and-publish:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run: docker buildx build .
+
 workflows:
   test:
     jobs:
@@ -26,3 +34,7 @@ workflows:
           filters:
             branches:
               only: master
+
+  cross-build:
+    jobs:
+      - cross-build-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,10 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - run: docker buildx build .
+      - run: | 
+          docker buildx build \
+            --platform linux/arm64/v8,linux/amd64
+            --tag darkphnx/ical-filter-proxy:buildx-latest .
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,24 @@ jobs:
     steps:
       - setup_remote_docker
       - checkout
-      - run: | 
-          docker buildx build \
-            --platform linux/arm64/v8,linux/amd64 \
-            --tag darkphnx/ical-filter-proxy:buildx-latest .
+      - run:
+          name: Setup buildx and qemu
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
+          name: Create builder
+          command: |
+            docker buildx create --name arm-builder
+            docker buildx use arm-builder
+            docker buildx inspect --bootstrap
+      - run: 
+          name: Cross-Build Image
+          command: | 
+            docker buildx build \
+              --platform linux/arm64/v8,linux/amd64 \
+              --tag darkphnx/ical-filter-proxy:buildx-latest .
 
 workflows:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,6 @@ jobs:
               --tag darkphnx/ical-filter-proxy:buildx-latest .
 
 workflows:
-  test:
-    jobs:
-      - test
-
   build-and-publish-docker-image:
     jobs:
       - docker/publish:
@@ -58,4 +54,5 @@ workflows:
 
   cross-build:
     jobs:
+      - test
       - cross-build-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,4 +55,6 @@ workflows:
   cross-build:
     jobs:
       - test
-      - cross-build-and-publish
+      - cross-build-and-publish:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           name: Cross-Build Image
           command: | 
             docker buildx build --push \
-              --platform linux/arm64/v8,linux/amd64 \
-              --tag darkphnx/ical-filter-proxy:buildx-latest .
+              --platform linux/arm64,linux/amd64 \
+              --tag darkphnx/ical-filter-proxy:latest .
 
 workflows:
   build-and-publish-docker-image:
@@ -56,6 +56,6 @@ workflows:
       - cross-build-and-publish:
           requires:
             - test
-          filters:
-            branches:
-              only: master
+         # filters:
+         #   branches:
+         #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,14 @@ workflows:
     jobs:
       - docker/publish:
           image: darkphnx/ical-filter-proxy
-          filters:
-            branches:
-              only: master
+          
 
-  cross-build:
+  test-and-build:
     jobs:
       - test
       - cross-build-and-publish:
           requires:
             - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
       - run:
           name: Create builder
           command: |
-            docker buildx create --name arm-builder
+            docker context create cross-builder
+            docker buildx create --name cross-builder cross-builder
             docker buildx use arm-builder
             docker buildx inspect --bootstrap
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,13 @@ jobs:
             docker buildx create --name cross-builder cross-builder
             docker buildx use cross-builder
             docker buildx inspect --bootstrap
+      - run:
+          name: Login to Dockerhub
+          command: echo "${!DOCKER_PASSWORD}" | docker login -u "${!DOCKER_LOGIN}" --password-stdin
       - run: 
           name: Cross-Build Image
           command: | 
-            docker buildx build \
+            docker buildx build --push \
               --platform linux/arm64/v8,linux/amd64 \
               --tag darkphnx/ical-filter-proxy:buildx-latest .
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run: | 
           docker buildx build \
-            --platform linux/arm64/v8,linux/amd64
+            --platform linux/arm64/v8,linux/amd64 \
             --tag darkphnx/ical-filter-proxy:buildx-latest .
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,18 +44,12 @@ jobs:
               --tag darkphnx/ical-filter-proxy:latest .
 
 workflows:
-  build-and-publish-docker-image:
-    jobs:
-      - docker/publish:
-          image: darkphnx/ical-filter-proxy
-          
-
   test-and-build:
     jobs:
       - test
       - cross-build-and-publish:
           requires:
             - test
-         # filters:
-         #   branches:
-         #     only: master
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
In response to #27, this PR provides multi-arch docker images.

Arm64 and Amd64 versions of the docker image are now automatically build and provided on Dockerhub at https://hub.docker.com/r/darkphnx/ical-filter-proxy