### PR TITLE
Add Monitoring Endpoint

### DIFF
--- a/lib/ical_filter_proxy/servers/rack_app.rb
+++ b/lib/ical_filter_proxy/servers/rack_app.rb
@@ -11,6 +11,11 @@ module IcalFilterProxy
         request = Rack::Request.new(env)
 
         requested_calendar = request.path_info.sub(/^\//, '')
+
+        if requested_calendar.strip.empty?
+          return [200, { 'content-type' => 'text/plain' }, ['Welcome to ical-filter-proxy']]
+        end
+
         ical_calendar = calendars[requested_calendar]
 
         if ical_calendar


### PR DESCRIPTION
Add endpoint which can be used for monitoring. Not specifying calendar will only return welcome instead of calendar not found