### PR TITLE
Update filter_rule.rb

### DIFF
--- a/lib/ical_filter_proxy/filter_rule.rb
+++ b/lib/ical_filter_proxy/filter_rule.rb
@@ -13,6 +13,8 @@ module IcalFilterProxy
 
     def match_event?(filterable_event)
       event_data = filterable_event.send(field.to_sym)
+      return false if event_data.nil?  # Check if event_data is null
+    
       negation ^ evaluate(event_data, values)
     end
 


### PR DESCRIPTION
Per: https://github.com/darkphnx/ical-filter-proxy/issues/48

This accounts for event_data is rendering null by returning False for a match. It resolves the issue with Google ICS feeds where an expected field is not present.